### PR TITLE
refactor: sort entities based on their priorities

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -91,8 +91,8 @@ const serialiseWith =
 		if (!msg.entities || msg.entities.length === 0) return serialiser(msg.text);
 
 		const entities = msg.entities.sort((a, b) => {
-			if(a.offset < b.offset) return -1;
-			if(a.offset > b.offset) return 1;
+			if (a.offset < b.offset) return -1;
+			if (a.offset > b.offset) return 1;
 			if (a.length > b.length) return -1;
 			if (a.length < b.length) return 1;
 			const a_priority = TYPE_PRIORITY[a.type];

--- a/mod.ts
+++ b/mod.ts
@@ -19,6 +19,8 @@ const TYPE_PRIORITY: Record<MessageEntity["type"], number> = {
 	phone_number: 50,
 	underline: 92,
 	strikethrough: 93,
+	// @ts-expect-error hasn't landed in telegraf/types yet.
+	blockquote: 0,
 	spoiler: 94,
 	custom_emoji: 99,
 };

--- a/mod.ts
+++ b/mod.ts
@@ -2,6 +2,7 @@ import * as serialisers from "./serialisers.ts";
 import * as escapers from "./escapers.ts";
 import type { Message, TextMessage, Tree, MessageEntity } from "./types.ts";
 
+// https://github.com/tdlib/td/blob/d79bd4b69403868897496da39b773ab25c69f6af/td/telegram/MessageEntity.cpp#L39
 const TYPE_PRIORITY: Record<MessageEntity["type"], number> = {
 	mention: 50,
 	hashtag: 50,
@@ -90,13 +91,15 @@ const serialiseWith =
 		if (!msg.entities || msg.entities.length === 0) return serialiser(msg.text);
 
 		const entities = msg.entities.sort((a, b) => {
-			if (a.offset !== b.offset) {
-				return a.offset < b.offset ? -1 : 1;
-			}
-			if (a.length !== b.length) {
-				return a.length > b.length ? -1 : 1;
-			}
-			return TYPE_PRIORITY[a.type] < TYPE_PRIORITY[b.type] ? -1 : 1;
+			if(a.offset < b.offset) return -1;
+			if(a.offset > b.offset) return 1;
+			if (a.length > b.length) return -1;
+			if (a.length < b.length) return 1;
+			const a_priority = TYPE_PRIORITY[a.type];
+			const b_priority = TYPE_PRIORITY[b.type];
+			if (a_priority < b_priority) return -1;
+			if (a_priority > b_priority) return 1;
+			return 0;
 		});
 
 		return serialse(toTree({ text: msg.text, entities }), serialiser, escaper);

--- a/mod.ts
+++ b/mod.ts
@@ -94,7 +94,7 @@ const serialiseWith =
 				return a.offset < b.offset ? -1 : 1;
 			}
 			if (a.length !== b.length) {
-				return a.length < b.length ? -1 : 1;
+				return a.length > b.length ? -1 : 1;
 			}
 			return TYPE_PRIORITY[a.type] < TYPE_PRIORITY[b.type] ? -1 : 1;
 		});

--- a/mod.ts
+++ b/mod.ts
@@ -40,7 +40,7 @@ const ends = (entity: MessageEntity) => entity.offset + entity.length;
 export function toTree(msg: TextMessage, offset = 0, upto = Infinity) {
 	if (!msg.entities?.length) return [msg.text.slice(offset, upto)];
 
-	let nodes: Tree = [];
+	const nodes: Tree = [];
 
 	let last = offset;
 

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,4 @@
-import type { MessageEntity } from "https://deno.land/x/telegraf_types@v6.8.1/message.ts";
+import type { MessageEntity } from "https://deno.land/x/telegraf_types@v6.9.1/message.ts";
 
 export type { MessageEntity };
 


### PR DESCRIPTION
This updates the compare function used for sorting entities, to make use of the entity priorities defined by TDLib. Linking references below:

- https://github.com/tdlib/td/blob/d79bd4b69403868897496da39b773ab25c69f6af/td/telegram/MessageEntity.cpp#L39
- https://github.com/tdlib/td/blob/d79bd4b69403868897496da39b773ab25c69f6af/td/telegram/MessageEntity.h#L91